### PR TITLE
Update ingresss api version

### DIFF
--- a/kubernetes/ingress.yaml
+++ b/kubernetes/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: hello-kubernetes


### PR DESCRIPTION
Fixes this error message:

```
$ kubectl apply -f ingress.yaml
Warning: extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
ingress.extensions/hello-kubernetes created
```